### PR TITLE
Follow Some `cargo clippy` suggestions

### DIFF
--- a/src/chapter2/more_params.md
+++ b/src/chapter2/more_params.md
@@ -36,7 +36,7 @@ macro_rules! impl_system_param {
     (
         $($params:ident),*
     ) => {
-        #[allow(unused)]
+        #[allow(unused, clippy::unused_unit)]
         impl<$($params: SystemParam),*> SystemParam for ($($params,)*) {
             type Item<'new> = ($($params::Item<'new>,)*);
 

--- a/src/chapter3/src/interior_mutability.rs
+++ b/src/chapter3/src/interior_mutability.rs
@@ -71,7 +71,7 @@ impl<'res, T: 'static> SystemParam for Res<'res, T> {
 
     fn retrieve<'r>(resources: &'r HashMap<TypeId, RefCell<Box<dyn Any>>>) -> Self::Item<'r> {
         Res {
-            value: resources.get(&TypeId::of::<T>()).unwrap().borrow(),
+            value: resources[&TypeId::of::<T>()].borrow(),
             _marker: PhantomData,
         }
     }
@@ -84,7 +84,7 @@ impl<'res, T: 'static> SystemParam for ResMut<'res, T> {
 
     fn retrieve<'r>(resources: &'r HashMap<TypeId, RefCell<Box<dyn Any>>>) -> Self::Item<'r> {
         ResMut {
-            value: resources.get(&TypeId::of::<T>()).unwrap().borrow_mut(),
+            value: resources[&TypeId::of::<T>()].borrow_mut(),
             _marker: PhantomData,
         }
     }


### PR DESCRIPTION
Thank you for your brilliant tutorial!

I fixes some clippy warnings in this PR. 

By the way, I also found many places which can be improved, may I work on improving them? 
- In Chapter1 & 2, many macros' matcher includes both `+` and `?`, I improved with `*` and it works.
- Some lifetimes can be elided
For example
```rust
impl<'res, T: 'static> SystemParam for Res<'res, T> {
    type Item<'new> = Res<'new, T>;

    fn retrieve<'r>(resources: &'r HashMap<TypeId, RefCell<Box<dyn Any>>>) -> Self::Item<'r> {
        Res {
            value: resources.get(&TypeId::of::<T>()).unwrap().borrow(),
            _marker: PhantomData,
        }
    }
}
```
Can be written into
```rust
impl<T: 'static> SystemParam for Res<'_, T> {
    type Item<'new> = Res<'new, T>;

    fn retrieve(resources: &HashMap<TypeId, RefCell<Box<dyn Any>>>) -> Self::Item<'_> {
        Res {
            value: resources[&TypeId::of::<T>()].borrow(),
            _marker: Default::default(),
        }
    }
}
```

These elisions may make learning a little more confused, so I ask for your advice.