### PR TITLE
Fix typo in system.md

### DIFF
--- a/src/chapter1/system.md
+++ b/src/chapter1/system.md
@@ -91,7 +91,7 @@ trait System {
     fn run(&mut self, resources: &mut HashMap<TypeId, Box<dyn Any>>);
 }
 
-impl<F: FnMut()> System<()> for FunctionSystem<(), F> {
+impl<F: FnMut()> System for FunctionSystem<(), F> {
     fn run(&mut self, resources: &mut HashMap<TypeId, Box<dyn Any>>) {
         (self.f)()
     }


### PR DESCRIPTION
This is after System has been made a parameter-free trait, so the `<()>` is no longer necessary